### PR TITLE
chore: add vue 3 essential plugin for eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ extends:
   - prettier/@typescript-eslint
   - plugin:prettier/recommended
   - plugin:vue/essential
+  - plugin:vue/vue3-essential
   - '@vue/typescript'
 parser: vue-eslint-parser
 parserOptions:


### PR DESCRIPTION
Added vue 3 plugin for eslint. So we'll never forget to add `.value` 😆 

list of rules: https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention-for-vue-js-3-x

before:
![image](https://user-images.githubusercontent.com/342666/107144565-09a2e200-694d-11eb-9ac4-6b434747ad9e.png)

after:
![image](https://user-images.githubusercontent.com/342666/107144574-19bac180-694d-11eb-90b4-64baa34ccaf1.png)
