### PR TITLE
feat(theme): add cssVarPrefix to config of theme

### DIFF
--- a/.changeset/forty-bulldogs-know.md
+++ b/.changeset/forty-bulldogs-know.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/vue-theme": minor
+---
+
+add cssVarPrefix with charka as default to theme config

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -7,6 +7,7 @@ export type ColorMode = "light" | "dark"
 export interface ColorModeOptions {
   initialColorMode?: ColorMode
   useSystemColorMode?: boolean
+  cssVarPrefix?: string
 }
 
 /**
@@ -15,6 +16,7 @@ export interface ColorModeOptions {
 const config: ColorModeOptions = {
   useSystemColorMode: false,
   initialColorMode: "light",
+  cssVarPrefix: "chakra",
 }
 
 export const theme = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add config option key to Chakra-ui-theme

## Motivation and Context
We didn't make use of the config option key and cssVarPrefix that are available in the Chakra-UI/Styled-system package

## How Has This Been Tested?
Not sure how to test this. Tried on a playground project.

## Screenshots (if appropriate):
<img width="354" alt="Screenshot 2021-09-20 at 11 35 28" src="https://user-images.githubusercontent.com/16015740/134201461-d7671332-cdc3-419b-9e18-067658f250d7.png">
<img width="390" alt="Screenshot 2021-09-20 at 11 40 53" src="https://user-images.githubusercontent.com/16015740/134201471-98be9189-4050-4e65-94aa-b923fe40a46d.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
