### PR TITLE
fix(reactivity): fix useStyleConfig themingProp reactivity

### DIFF
--- a/packages/c-accordion/src/accordion.tsx
+++ b/packages/c-accordion/src/accordion.tsx
@@ -105,11 +105,7 @@ export const CAccordion: ComponentWithProps<DeepPartial<CAccordionProps>> =
         })
       )
 
-      const styles = useMultiStyleConfig("Accordion", {
-        ...props.value,
-        ...themingProps.value,
-        ...attrs,
-      })
+      const styles = useMultiStyleConfig("Accordion", themingProps)
 
       const reduceMotion = computed(() => props.value.reduceMotion)
 
@@ -233,7 +229,7 @@ export const CAccordionButton: ComponentWithProps<CAccordionButtonProps> =
           __css={buttonStyles.value}
           {...attrs}
         >
-          {getValidChildren(slots)}
+          {() => getValidChildren(slots)}
         </chakra.button>
       )
     },

--- a/packages/c-alert/src/alert.tsx
+++ b/packages/c-alert/src/alert.tsx
@@ -81,7 +81,7 @@ export const CAlert = defineComponent({
   },
   setup(props, { slots, attrs }) {
     const colorScheme = computed<string>(
-      () => props.colorScheme || STATUSES[props.status].colorScheme
+      () => props.colorScheme || STATUSES[props?.status]?.colorScheme
     )
 
     const themingProps = computed<ThemingProps>(() => ({
@@ -90,7 +90,7 @@ export const CAlert = defineComponent({
     }))
 
     AlertProvider({ status: computed(() => props.status) })
-    const styles = useMultiStyleConfig("Alert", themingProps.value)
+    const styles = useMultiStyleConfig("Alert", themingProps)
     StylesProvider(styles)
 
     const alertStyles = computed<SystemStyleObject>(() => ({
@@ -110,7 +110,7 @@ export const CAlert = defineComponent({
           __css={alertStyles.value}
           {...attrs}
         >
-          {slots}
+          {() => getValidChildren(slots)}
         </chakra.div>
       )
     }
@@ -125,8 +125,9 @@ export const CAlert = defineComponent({
 export const CAlertTitle = defineComponent({
   name: "CAlertTitle",
   setup(_, { attrs, slots }) {
+    const styles = useStyles()
+
     return () => {
-      const styles = useStyles()
 
       return (
         <chakra.div
@@ -157,7 +158,7 @@ export const CAlertDescription = defineComponent({
           __css={styles.value.description}
           {...attrs}
         >
-          {slots}
+          {() => getValidChildren(slots)}
         </chakra.div>
       )
     }

--- a/packages/c-breadcrumb/src/c-breadcrumb.tsx
+++ b/packages/c-breadcrumb/src/c-breadcrumb.tsx
@@ -26,6 +26,7 @@ import {
   isObjectComponent,
   SNA,
   SNAO,
+  vueThemingProps,
 } from "@chakra-ui/vue-utils"
 import { DOMElements } from "@chakra-ui/vue-system"
 
@@ -68,7 +69,7 @@ export const CBreadcrumb: DefineComponent<BreadcrumbProps> = defineComponent(
       })
     )
 
-    const styles = useMultiStyleConfig("Breadcrumb", themingProps.value)
+    const styles = useMultiStyleConfig("Breadcrumb", themingProps)
     StylesProvider(styles)
 
     const separator = computed(() => {
@@ -132,6 +133,7 @@ CBreadcrumb.props = {
     type: [String, Object] as PropType<DOMElements | object | string>,
     default: "nav",
   },
+  ...vueThemingProps,
 }
 
 /**

--- a/packages/c-button/src/button.tsx
+++ b/packages/c-button/src/button.tsx
@@ -21,7 +21,7 @@ import { CIcon, IconProps } from "@chakra-ui/c-icon"
 import { CSpinner } from "@chakra-ui/c-spinner"
 import { ButtonProps, defaultButtonProps } from "./button.utils"
 import { SystemProps } from "@chakra-ui/styled-system"
-import { SNAO, vueThemingProps } from "@chakra-ui/vue-utils"
+import { SNAO, vueThemingProps, getValidChildren } from "@chakra-ui/vue-utils"
 
 export interface CButtonSpinnerProps extends HTMLChakraProps<"div"> {
   label?: string
@@ -153,7 +153,7 @@ export const CButton: ComponentWithProps<DeepPartial<CButtonProps>> =
       ...vueThemingProps,
     },
     setup(_props, { attrs, slots }) {
-      const props = computed<ButtonProps>(() =>
+      const props = computed(() =>
         mergeWith({}, defaultButtonProps, _props, attrs)
       )
       const themingProps = computed<ThemingProps>(() =>
@@ -166,11 +166,10 @@ export const CButton: ComponentWithProps<DeepPartial<CButtonProps>> =
       )
 
       const group = useButtonGroup()
-      const styles = useStyleConfig("Button", {
-        ...group?.value,
-        ...themingProps.value,
-        ...attrs,
-      })
+      const styles = useStyleConfig(
+        "Button",
+        computed(() => ({ ...group?.value, ...themingProps.value }))
+      )
 
       const _focus = computed<SystemStyleObject>(() =>
         mergeWith({}, styles.value?.["_focus"] ?? {}, {
@@ -242,7 +241,7 @@ export const CButton: ComponentWithProps<DeepPartial<CButtonProps>> =
                     rightIcon={props.value.rightIcon}
                     iconSpacing={props.value.iconSpacing}
                   >
-                    {slots}
+                    {() => getValidChildren(slots)}
                   </CButtonContent>
                 )}
                 {props.value.isLoading &&

--- a/packages/c-close-button/src/c-close-button.ts
+++ b/packages/c-close-button/src/c-close-button.ts
@@ -68,7 +68,7 @@ export const CCloseButton = defineComponent({
         flexShrink: 0,
       }
 
-      const styles = useStyleConfig("CloseButton", themingProps.value)
+      const styles = useStyleConfig("CloseButton", themingProps)
 
       return h(
         chakra(props.as, {

--- a/packages/c-code/src/code.ts
+++ b/packages/c-code/src/code.ts
@@ -17,17 +17,17 @@ const CCode = defineComponent({
     ...vueThemingProps,
   },
   setup(props, { slots, attrs }) {
-    return () => {
-      const themingProps = computed<ThemingProps>(() =>
-        filterUndefined({
-          colorScheme: props.colorScheme,
-          variant: props.variant,
-          size: props.size,
-          styleConfig: props.styleConfig,
-        })
-      )
-      const styles = useStyleConfig("Code", themingProps.value)
+    const themingProps = computed<ThemingProps>(() =>
+      filterUndefined({
+        colorScheme: props.colorScheme,
+        variant: props.variant,
+        size: props.size,
+        styleConfig: props.styleConfig,
+      })
+    )
+    const styles = useStyleConfig("Code", themingProps)
 
+    return () => {
       return h(
         chakra(props.as, {
           __css: {

--- a/packages/c-input/src/c-input-group.tsx
+++ b/packages/c-input/src/c-input-group.tsx
@@ -29,7 +29,7 @@ export const CInputGroup = defineComponent({
   },
   setup(props, { slots, attrs }) {
     const styleAttrs = computed(() => mergeProps(attrs, props))
-    const styles = useMultiStyleConfig("Input", styleAttrs.value)
+    const styles = useMultiStyleConfig("Input", styleAttrs)
     const input = computed(() => styles.value?.field)
     const unthemedProps = computed(() => omitThemingProps(styleAttrs.value))
 

--- a/packages/c-modal/src/c-modal.ts
+++ b/packages/c-modal/src/c-modal.ts
@@ -248,8 +248,9 @@ export const CModal: ComponentWithProps<CModalProps> = defineComponent({
       emit("escape", event)
       emit("closeModal", false)
     }
+    const mergedProps = computed(() => mergeProps(props, attrs))
 
-    const styles = useMultiStyleConfig("Modal", mergeProps(props, attrs))
+    const styles = useMultiStyleConfig("Modal", mergedProps)
     const modalOptions = reactive({
       ...toRefs(reactive(props)),
       closeModal,

--- a/packages/c-spinner/src/spinner.tsx
+++ b/packages/c-spinner/src/spinner.tsx
@@ -113,7 +113,7 @@ const CSpinner: ComponentWithProps<DeepPartial<CSpinnerProps>> =
         size: props.value.size,
         styleConfig: props.value.styleConfig,
       }))
-      const styles = useStyleConfig("Spinner", { ...themingProps.value })
+      const styles = useStyleConfig("Spinner", themingProps)
       const spinnerStyles = computed<SystemStyleObject>(() => ({
         display: "inline-block",
         borderColor: "currentColor",

--- a/packages/c-tag/src/c-tag.tsx
+++ b/packages/c-tag/src/c-tag.tsx
@@ -46,7 +46,7 @@ export const CTagLabel: ComponentWithProps<CTagLabelProps> = defineComponent({
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useMultiStyleConfig("Tag", themingProps.value)
+    const styles = useMultiStyleConfig("Tag", themingProps)
 
     return () => (
       <chakra.span __css={styles.value.label} noOfLines={1} {...attrs}>
@@ -98,7 +98,7 @@ export const CTagCloseButton: ComponentWithProps<CTagCloseButtonProps> =
         })
       )
 
-      const styles = useMultiStyleConfig("Tag", themingProps.value)
+      const styles = useMultiStyleConfig("Tag", themingProps)
 
       const buttonStyles: SystemStyleObject = {
         display: "flex",
@@ -135,7 +135,7 @@ export const CTag: ComponentWithProps<CTagProps> = defineComponent({
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useMultiStyleConfig("Tag", themingProps.value)
+    const styles = useMultiStyleConfig("Tag", themingProps)
     const tagContainerStyles = computed<SystemStyleObject>(() => ({
       ...styles.value.container,
       bg: props.variantColor ?? styles.value.container.bg,

--- a/packages/layout/src/badge.tsx
+++ b/packages/layout/src/badge.tsx
@@ -41,7 +41,7 @@ export const CBadge: ComponentWithProps<
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Badge", themingProps.value)
+    const styles = useStyleConfig("Badge", themingProps)
     return () => {
       return (
         <chakra.div

--- a/packages/layout/src/container.tsx
+++ b/packages/layout/src/container.tsx
@@ -52,7 +52,7 @@ export const CContainer: ComponentWithProps<
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Container", themingProps.value)
+    const styles = useStyleConfig("Container", themingProps)
 
     return () => (
       <chakra.div

--- a/packages/layout/src/divider.tsx
+++ b/packages/layout/src/divider.tsx
@@ -44,7 +44,7 @@ export const CDivider: ComponentWithProps<
       })
     )
 
-    const styles = useStyleConfig("Divider", themingProps.value)
+    const styles = useStyleConfig("Divider", themingProps)
 
     const {
       borderLeftWidth,

--- a/packages/layout/src/heading.tsx
+++ b/packages/layout/src/heading.tsx
@@ -35,7 +35,7 @@ export const CHeading: ComponentWithProps<
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Heading", themingProps.value)
+    const styles = useStyleConfig("Heading", themingProps)
 
     return () => (
       <chakra.h2

--- a/packages/layout/src/kbd.tsx
+++ b/packages/layout/src/kbd.tsx
@@ -43,7 +43,7 @@ export const CKbd: ComponentWithProps<DeepPartial<KbdProps>> = defineComponent({
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Kbd", themingProps.value)
+    const styles = useStyleConfig("Kbd", themingProps)
 
     return () => (
       <chakra.kbd

--- a/packages/layout/src/link.tsx
+++ b/packages/layout/src/link.tsx
@@ -52,7 +52,7 @@ export const CLink: ComponentWithProps<
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Link", themingProps.value)
+    const styles = useStyleConfig("Link", themingProps)
 
     return () => (
       <chakra.a

--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -58,7 +58,7 @@ export const CText: ComponentWithProps<
         styleConfig: props.styleConfig,
       })
     )
-    const styles = useStyleConfig("Text", themingProps.value)
+    const styles = useStyleConfig("Text", themingProps)
 
     const aliasedProps = computed(() =>
       filterUndefined({

--- a/packages/system/src/composables/use-style-config.ts
+++ b/packages/system/src/composables/use-style-config.ts
@@ -1,4 +1,4 @@
-import { computed, ComputedRef } from "vue"
+import { computed, ComputedRef, Ref } from "vue"
 import { SystemStyleObject } from "@chakra-ui/styled-system"
 import { ThemingProps } from "../system.types"
 import { filterUndefined, get, mergeWith, runIfFn } from "@chakra-ui/utils"
@@ -11,9 +11,22 @@ export function useStyleConfig<Component extends keyof Theme["components"]>(
   options: { isMultiPart: true }
 ): ComputedRef<Record<string, SystemStyleObject>>
 
+
+export function useStyleConfig<Component extends keyof Theme["components"]>(
+  themeKey: Component,
+  themingProps: Ref<ThemingProps>,
+  options: { isMultiPart: true }
+): ComputedRef<Record<string, SystemStyleObject>>
+
 export function useStyleConfig<Component extends keyof Theme["components"]>(
   themeKey: Component,
   themingProps?: ThemingProps,
+  options?: { isMultiPart?: boolean }
+): ComputedRef<SystemStyleObject>
+
+export function useStyleConfig<Component extends keyof Theme["components"]>(
+  themeKey: Component,
+  themingProps?: Ref<ThemingProps>,
   options?: { isMultiPart?: boolean }
 ): ComputedRef<SystemStyleObject>
 
@@ -23,7 +36,7 @@ export function useStyleConfig<Component extends keyof Theme["components"]>(
   options: any = {}
 ) {
   return computed(() => {
-    const { styleConfig: styleConfigProp, ...rest } = themingProps
+    const { styleConfig: styleConfigProp, ...rest } = themingProps.value || themingProps
     const { theme, colorMode } = useChakra()
     const themeStyleConfig = get(theme, `components.${themeKey}`)
 

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -120,5 +120,6 @@ const defaultProps = {
 export default {
   parts: parts.keys,
   baseStyle,
+  sizes,
   defaultProps,
 }


### PR DESCRIPTION
Signed-off-by: Shyrro <zsahmane@gmail.com>

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, style props are not always reactive. 

See example : https://codesandbox.io/s/charka-ui-vue-chidori-test-playground-forked-f8h0c2?file=/src/App.vue

It is working for other components because they either pass the `props` to the `useStyleConfig` composable, or call the composable inside the render function of the setup which causes the composable to be called everytime even when not needed.

For components that are not working, it is because the `computed` behind the `useStylesConfig` can't track the unwrapped values that are passed.

Fixes: #97

## What is the new behavior?

We now allow the composable `useStylesConfig` to take a `Ref<ThemingProps>` instead of just `ThemingProps`, so that the changes can be tracked. 
This does not impact already working components that used to take props, because it is an addition, if the object passed is not a ref object, the old behavior will apply.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Some components were missing either objects in config or not calling  `computed` method on passed object so i added them too.
