### PR TITLE
Create Media Query components and `useQuery` composable

### DIFF
--- a/packages/c-media-query/README.md
+++ b/packages/c-media-query/README.md
@@ -1,0 +1,11 @@
+# @chakra-ui/media-query
+
+Media query components and composables
+
+## Installation
+
+```sh
+yarn add @chakra-ui/media-query
+# or
+npm i @chakra-ui/media-query
+```

--- a/packages/c-media-query/examples/show-hide.vue
+++ b/packages/c-media-query/examples/show-hide.vue
@@ -1,11 +1,17 @@
 <template>
   <div>
-    <c-show above="md">
-      <p>This is shown above the 'md' breakpoint</p>
+    <c-show above="sm">
+      <div>Hey! I'll show above sm (480px)</div>
     </c-show>
-    <c-hide above="lg">
-      <p>This hides above the 'lg' breakpoint</p>
+    <c-hide below="md">
+      <div>Hello!! I'll hide below md (768px)</div>
     </c-hide>
+    <c-hide breakpoint="(max-width: 400px)">
+      <div>Hello!! I'll be hidden at or below 400px</div>
+    </c-hide>
+    <c-show breakpoint="(max-width: 400px)">
+      <div>Hello!! I'll be shown at or below 400px</div>
+    </c-show>
   </div>
 </template>
 <script setup lang="ts">

--- a/packages/c-media-query/examples/show-hide.vue
+++ b/packages/c-media-query/examples/show-hide.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <c-show above="md">
+      <p>This is shown above the 'md' breakpoint</p>
+    </c-show>
+    <c-hide above="lg">
+      <p>This hides above the 'lg' breakpoint</p>
+    </c-hide>
+  </div>
+</template>
+<script setup lang="ts">
+import { CShow, CHide } from "../src/index"
+</script>

--- a/packages/c-media-query/index.tsx
+++ b/packages/c-media-query/index.tsx
@@ -1,0 +1,1 @@
+export * from './src'

--- a/packages/c-media-query/package.json
+++ b/packages/c-media-query/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@chakra-ui/c-media-query",
+  "description": "Chakra UI Vue | Media query components and composables",
+  "version": "0.0.0-alpha.0",
+  "main": "dist/chakra-ui-c-media-query.cjs.js",
+  "module": "dist/chakra-ui-c-media-query.esm.js",
+  "author": "Jonathan Bakebwa <codebender828@gmail.com>",
+  "homepage": "https://github.com/chakra-ui/chakra-ui-vue-next#readme",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "require": "./dist/chakra-ui-c-media-query.cjs.js",
+      "default": "./dist/chakra-ui-c-media-query.esm.js"
+    }
+  },
+  "repository": "https://github.com/chakra-ui/chakra-ui-vue-next/tree/master/packages/c-media-query",
+  "bugs": {
+    "url": "https://github.com/chakra-ui/chakra-ui-vue-next/issues"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@chakra-ui/vue-system": "0.1.0-alpha.10",
+    "@chakra-ui/vue-utils": "0.1.0-alpha.10",
+    "@vueuse/core": "4.9.1"
+  },
+  "devDependencies": {
+    "vue": "^3.2.37"
+  },
+  "peerDependencies": {
+    "vue": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/c-media-query/src/c-hide.tsx
+++ b/packages/c-media-query/src/c-hide.tsx
@@ -7,6 +7,9 @@ import { CShowProps } from "./c-show"
 
 export interface CHideProps extends CShowProps {}
 
+/**
+ * Wrapper component to hide child elements based on breakpoint value
+ */
 export const CHide: ComponentWithProps<CHideProps> = defineComponent({
   props: {
     breakpoint: {

--- a/packages/c-media-query/src/c-hide.tsx
+++ b/packages/c-media-query/src/c-hide.tsx
@@ -1,0 +1,30 @@
+import { h, defineComponent, PropType, unref } from "vue"
+import { getValidChildren } from "@chakra-ui/vue-utils"
+import { CVisibility } from "./c-visibility"
+import { useQuery } from "./use-query"
+import { ComponentWithProps } from "@chakra-ui/vue-system"
+import { CShowProps } from "./c-show"
+
+export interface CHideProps extends CShowProps {}
+
+export const CHide: ComponentWithProps<CHideProps> = defineComponent({
+  props: {
+    breakpoint: {
+      type: String as PropType<CHideProps["breakpoint"]>,
+    },
+    above: {
+      type: String as PropType<CHideProps["above"]>,
+    },
+    below: {
+      type: String as PropType<CHideProps["below"]>,
+    },
+  },
+  setup(props, { slots }) {
+    const query = useQuery(props)
+    return () => (
+      <CVisibility breakpoint={unref(query)} hide>
+        {() => getValidChildren(slots)}
+      </CVisibility>
+    )
+  },
+})

--- a/packages/c-media-query/src/c-hide.tsx
+++ b/packages/c-media-query/src/c-hide.tsx
@@ -25,7 +25,7 @@ export const CHide: ComponentWithProps<CHideProps> = defineComponent({
   setup(props, { slots }) {
     const query = useQuery(props)
     return () => (
-      <CVisibility breakpoint={unref(query)} hide>
+      <CVisibility breakpoint={query.value} hide>
         {() => getValidChildren(slots)}
       </CVisibility>
     )

--- a/packages/c-media-query/src/c-show.tsx
+++ b/packages/c-media-query/src/c-show.tsx
@@ -41,7 +41,7 @@ export const CShow: ComponentWithProps<CShowProps> = defineComponent({
     const query = useQuery(props)
     return () => {
       return (
-        <CVisibility breakpoint={unref(query)}>
+        <CVisibility breakpoint={query.value}>
           {() => getValidChildren(slots)}
         </CVisibility>
       )

--- a/packages/c-media-query/src/c-show.tsx
+++ b/packages/c-media-query/src/c-show.tsx
@@ -1,0 +1,47 @@
+import { h, defineComponent, PropType, unref } from "vue"
+import { getValidChildren } from "@chakra-ui/vue-utils"
+import { CVisibility } from "./c-visibility"
+import { useQuery } from "./use-query"
+import { ComponentWithProps } from "@chakra-ui/vue-system"
+
+export interface CShowProps {
+  /**
+   * A custom css media query that determines when the `slots` are rendered.
+   * Will render `slots` if that query resolves to `true`.
+   */
+  breakpoint?: string
+  /**
+   * A value from the `breakpoints` section in the theme. Will render `slots`
+   * from that breakpoint and below. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   */
+  below?: string
+  /**
+   * A value from the `breakpoints` section in the theme. Will render `slots`
+   * from that breakpoint and above. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   */
+  above?: string
+}
+
+export const CShow: ComponentWithProps<CShowProps> = defineComponent({
+  props: {
+    breakpoint: {
+      type: String as PropType<CShowProps["breakpoint"]>,
+    },
+    above: {
+      type: String as PropType<CShowProps["above"]>,
+    },
+    below: {
+      type: String as PropType<CShowProps["below"]>,
+    },
+  },
+  setup(props, { slots }) {
+    const query = useQuery(props)
+    return () => {
+      return (
+        <CVisibility breakpoint={unref(query)}>
+          {() => getValidChildren(slots)}
+        </CVisibility>
+      )
+    }
+  },
+})

--- a/packages/c-media-query/src/c-show.tsx
+++ b/packages/c-media-query/src/c-show.tsx
@@ -22,6 +22,9 @@ export interface CShowProps {
   above?: string
 }
 
+/**
+ * Wrapper component to show child elements based on breakpoint value
+ */
 export const CShow: ComponentWithProps<CShowProps> = defineComponent({
   props: {
     breakpoint: {

--- a/packages/c-media-query/src/c-visibility.tsx
+++ b/packages/c-media-query/src/c-visibility.tsx
@@ -1,0 +1,30 @@
+import { computed, defineComponent, PropType } from "vue"
+import { useMediaQuery } from "@vueuse/core"
+import { ComponentWithProps } from "@chakra-ui/vue-system"
+
+export interface CVisbilityProps {
+  /**
+   * Test
+   */
+  breakpoint: string
+  hide?: boolean
+}
+
+export const CVisibility: ComponentWithProps<CVisbilityProps> = defineComponent(
+  {
+    props: {
+      breakpoint: {
+        type: String as PropType<CVisbilityProps["breakpoint"]>,
+        required: true,
+      },
+      hide: Boolean as PropType<CVisbilityProps["hide"]>,
+    },
+    setup(props, { slots }) {
+      const show = useMediaQuery(props.breakpoint)
+
+      const isVisible = computed(() => (props.hide ? !show.value : show.value))
+
+      return () => (isVisible.value ? slots.default!() : null)
+    },
+  }
+)

--- a/packages/c-media-query/src/index.tsx
+++ b/packages/c-media-query/src/index.tsx
@@ -1,0 +1,4 @@
+export * from "./c-show"
+export * from "./c-hide"
+export * from "./c-visibility"
+export * from "./use-query"

--- a/packages/c-media-query/src/use-query.ts
+++ b/packages/c-media-query/src/use-query.ts
@@ -11,6 +11,9 @@ export interface UseQueryProps {
   above?: string
 }
 
+/**
+ * Returns a media query value based on theme breakpoint or given query string.
+ */
 export function useQuery(props: UseQueryProps) {
   const { breakpoint = "", below, above } = props
 

--- a/packages/c-media-query/src/use-query.ts
+++ b/packages/c-media-query/src/use-query.ts
@@ -1,0 +1,30 @@
+import { useTheme } from "@chakra-ui/vue-system"
+import { computed } from "vue"
+
+const getBreakpoint = (theme: Record<string, any>, value: any) => {
+  return theme?.breakpoints?.[value] ?? value
+}
+
+export interface UseQueryProps {
+  breakpoint?: string
+  below?: string
+  above?: string
+}
+
+export function useQuery(props: UseQueryProps) {
+  const { breakpoint = "", below, above } = props
+
+  const theme = useTheme()
+  const bpBelow = getBreakpoint(theme, below)
+  const bpAbove = getBreakpoint(theme, above)
+
+  const query = computed(() => {
+    if (bpAbove) return `(min-width: ${bpAbove})`
+
+    if (bpBelow) return `(max-width: ${bpBelow})`
+
+    return breakpoint
+  })
+
+  return query
+}

--- a/packages/c-media-query/tsconfig.json
+++ b/packages/c-media-query/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "./index.tsx", "./index.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@chakra-ui/c-form-control": "0.0.0-alpha.5",
     "@chakra-ui/c-icon": "1.0.0-alpha.10",
     "@chakra-ui/c-input": "0.0.0-alpha.5",
+    "@chakra-ui/c-media-query": "0.0.0-alpha.0",
     "@chakra-ui/c-modal": "1.1.0-alpha.10",
     "@chakra-ui/c-motion": "0.1.0-alpha.9",
     "@chakra-ui/c-popper": "0.1.0-alpha.10",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -149,6 +149,7 @@ export * from "@chakra-ui/c-input"
 export * from "@chakra-ui/vue-layout"
 
 // M
+export * from "@chakra-ui/c-media-query"
 export * from "@chakra-ui/c-modal"
 export * from "@chakra-ui/c-motion"
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
Tests in this PR come in the form of the UI examples, as there is no valid Jest test to apply.
(There would be testing the `useQuery`, but it needs a Provider for the theme and is not used directly in the `CShow`/`CHide` components.)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #181, Closes #183, Closes #184 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the `c-visibility` component.
- Adds the `c-show` and `c-hide` components
- Adds the `useQuery` composable

These items are housed in the `c-media-query` package.

> As of this PR, there are other composables waiting to be added to this set, and will be issued into future PRs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Originally a PR for `c-visbility` (hence the feature branch name), it was decided to bundle the set, as they are all individually small components/composables that are linked together, as the `c-show`/`c-hide` components are dependent on `c-visibility` and `useQuery`