### PR TITLE
chore(eslint): add `endOfLine` prettier rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,3 +25,6 @@ rules:
         delimiter: comma
         requireLast: false
   vue/no-multiple-template-root: "off"
+  "prettier/prettier":
+    - error
+    - endOfLine: "auto"


### PR DESCRIPTION
Add the `endOfLine: "auto"` prettier rule in the eslint config to prevent carriage return linting errors.