### PR TITLE
fix(theme): fix extendChakra theme

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ const ChakraUIVuePlugin: Plugin = {
     // 2. Parse theme tokens to CSS variables
     // 3. Inject all CSS variables as theme object
     const theme: Theme | (Omit<Theme, "components"> & { components: Dict }) =
-      options.extendTheme || options.isBaseTheme ? baseTheme : defaultTheme
+      options.extendTheme ?? (options.isBaseTheme ? baseTheme : defaultTheme)
     const computedTheme = computed<WithCSSVar<ThemeOverride>>(() =>
       toCSSVar(theme)
     )


### PR DESCRIPTION
Signed-off-by: Shyrro <zsahmane@gmail.com>

## Pull request checklist

Please check if your PR fulfills the following requirements:

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, the extendTheme was never taken into account unless it was undefined. When not, it would return the `baseTheme` .


## What is the new behavior?

This takes into the account the `extendTheme` as it was intended.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Using the `extendTheme` method from the react package seem to have slightly different results than when using the one from our repo. The difference is that that method uses the React files for the theme foundations.
The themes look fairly similar so i'm guessing we were doing some shenanigans related to our code base or i missed something. I might be wrong but i think this needs investigation. 
